### PR TITLE
Allow to disable requests security certificate check

### DIFF
--- a/igramscraper/instagram.py
+++ b/igramscraper/instagram.py
@@ -74,7 +74,7 @@ class Instagram:
         if proxy and isinstance(proxy, dict):
             self.__req.proxies = proxy
 
-    def diasable_verify(self):
+    def disable_verify(self):
         self.__req.verify = False
 
     def disable_proxies(self):

--- a/igramscraper/instagram.py
+++ b/igramscraper/instagram.py
@@ -74,6 +74,9 @@ class Instagram:
         if proxy and isinstance(proxy, dict):
             self.__req.proxies = proxy
 
+    def diasable_verify(self):
+        self.__req.verify = False
+
     def disable_proxies(self):
         self.__req.proxies = {}
 


### PR DESCRIPTION
Hi, I start to use this library with some proxy services (like Crawelera) and get certification error.
So I wanna add a method that allows disabling security certificate check.

occurred error:
```
HTTPSConnectionPool(host='www.instagram.com', port=443): Max retries exceeded with url: /holiday_official_jp/?__a=1 (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1056)')))
```

--------
Usage

```
instagram = Instagram()
instagram.set_proxies(PROXIES)
instagram.disable_verify()
```