### PR TITLE
Carousel media

### DIFF
--- a/igramscraper/model/carousel_media.py
+++ b/igramscraper/model/carousel_media.py
@@ -1,4 +1,4 @@
-class CarouselMedia:
+from .mixins import UtilsMixin
 
     def __init__(self):
         self.__type = ''
@@ -11,3 +11,4 @@ class CarouselMedia:
         self.__video_low_bandwidth_url = ''
         self.__video_views = ''
 
+class CarouselMedia(UtilsMixin):

--- a/igramscraper/model/carousel_media.py
+++ b/igramscraper/model/carousel_media.py
@@ -1,14 +1,15 @@
 from .mixins import UtilsMixin
 
-    def __init__(self):
-        self.__type = ''
-        self.__image_low_resolution_url = ''
-        self.__image_thumbnail_url = ''
-        self.__image_standard_resolution_url = ''
-        self.__image_high_resolution_url = ''
-        self.__video_low_resolution_url = ''
-        self.__video_standard_resolution_url = ''
-        self.__video_low_bandwidth_url = ''
-        self.__video_views = ''
 
 class CarouselMedia(UtilsMixin):
+
+    def __init__(self):
+        self.type = ''
+        self.image_thumbnail_url = ''
+        self.image_low_resolution_url = ''
+        self.image_standard_resolution_url = ''
+        self.image_high_resolution_url = ''
+        self.video_thumbnail_url = ''
+        self.video_low_resolution_url = ''
+        self.video_standard_resolution_url = ''
+        self.video_high_resolution_url = ''

--- a/igramscraper/model/media.py
+++ b/igramscraper/model/media.py
@@ -142,6 +142,7 @@ class Media(UtilsMixin, InitializerModel):
                 square_images_url.append(square_image['src'])
             self.square_images = square_images_url
 
+        # TODO Do we need this?
         elif prop == 'carousel_media':
             self.type = Media.TYPE_CAROUSEL
             self.carousel_media = []

--- a/igramscraper/model/media.py
+++ b/igramscraper/model/media.py
@@ -5,9 +5,10 @@ from .initializer_model import InitializerModel
 from .comment import Comment
 from .carousel_media import CarouselMedia
 from .. import endpoints
+from .mixins import UtilsMixin
 
 
-class Media(InitializerModel):
+class Media(UtilsMixin, InitializerModel):
     TYPE_IMAGE = 'image'
     TYPE_VIDEO = 'video'
     TYPE_SIDECAR = 'sidecar'

--- a/igramscraper/model/media.py
+++ b/igramscraper/model/media.py
@@ -129,13 +129,7 @@ class Media(UtilsMixin, InitializerModel):
             medias_url = []
             for media in value:
                 medias_url.append(media['src'])
-
-                if media['config_width'] == 640:
-                    self.image_thumbnail_url = media['src']
-                elif media['config_width'] == 750:
-                    self.image_low_resolution_url = media['src']
-                elif media['config_width'] == 1080:
-                    self.image_standard_resolution_url = media['src']
+                self.set_image_urls(media)
 
         elif prop == 'display_src' or prop == 'display_url':
             self.image_high_resolution_url = value

--- a/igramscraper/model/media.py
+++ b/igramscraper/model/media.py
@@ -240,12 +240,7 @@ class Media(UtilsMixin, InitializerModel):
             #     $this->sidecarMedias[] = static::create($edge['node']);
             # }
         elif prop == '__typename':
-            if value == 'GraphImage':
-                self.type = Media.TYPE_IMAGE
-            elif value == 'GraphVideo':
-                self.type = Media.TYPE_VIDEO
-            elif value == 'GraphSidecar':
-                self.type = Media.TYPE_SIDECAR
+            self.type = self.set_type(value)
 
         # if self.ownerId and self.owner != None:
         #     self.ownerId = self.getOwner().getId()
@@ -256,6 +251,14 @@ class Media(UtilsMixin, InitializerModel):
         print(carousel_array)
         # TODO implement
         pass
+    def set_type(self, value):
+        if value == 'GraphImage':
+            return Media.TYPE_IMAGE
+        elif value == 'GraphVideo':
+            return Media.TYPE_VIDEO
+        elif value == 'GraphSidecar':
+            return Media.TYPE_SIDECAR
+
         """
         param mediaArray
         param carouselArray

--- a/igramscraper/model/media.py
+++ b/igramscraper/model/media.py
@@ -221,30 +221,14 @@ class Media(UtilsMixin, InitializerModel):
                 pass
 
         elif prop == 'edge_sidecar_to_children':
-            pass
-            # #TODO implement
-            # if (!is_array($arr[$prop]['edges'])) {
-            #     break;
-            # }
-            # foreach ($arr[$prop]['edges'] as $edge) {
-            #     if (!isset($edge['node'])) {
-            #         continue;
-            #     }
+            self.set_carousel_media([], arr['edge_sidecar_to_children']['edges'])
 
-            #     $this->sidecarMedias[] = static::create($edge['node']);
-            # }
         elif prop == '__typename':
             self.type = self.set_type(value)
 
         # if self.ownerId and self.owner != None:
         #     self.ownerId = self.getOwner().getId()
 
-    @staticmethod
-    def set_carousel_media(media_array, carousel_array):
-
-        print(carousel_array)
-        # TODO implement
-        pass
     def set_type(self, value):
         if value == 'GraphImage':
             return Media.TYPE_IMAGE
@@ -253,6 +237,18 @@ class Media(UtilsMixin, InitializerModel):
         elif value == 'GraphSidecar':
             return Media.TYPE_SIDECAR
 
+    def set_carousel_media(self, media_array, carousel_array):
+        # TODO Do we need media_array? If yes, why?
+        for carousel in carousel_array:
+            carousel_media = CarouselMedia()
+            carousel_media.type = self.set_type(carousel["node"]["__typename"])
+            if carousel_media.type == Media.TYPE_IMAGE:
+                for media in carousel["node"]["display_resources"]:
+                    carousel_media.set_image_urls(media)
+            elif carousel_media.type == Media.TYPE_VIDEO:
+                # TODO Implement
+                pass
+            self.carousel_media.append(carousel_media)
         """
         param mediaArray
         param carouselArray

--- a/igramscraper/model/mixins.py
+++ b/igramscraper/model/mixins.py
@@ -1,0 +1,9 @@
+class UtilsMixin:
+
+    def set_image_urls(self, media):
+        if media['config_width'] == 640:
+            self.image_thumbnail_url = media['src']
+        elif media['config_width'] == 750:
+            self.image_low_resolution_url = media['src']
+        elif media['config_width'] == 1080:
+            self.image_standard_resolution_url = media['src']


### PR DESCRIPTION
Added UtilsMixin to be able to define shared methods
Added method set_image_urls
Added method set_type

Implemented method set_carousel_media.
- I've changed the signature to be an instance method to allow direct assignation to self.carousel_media list.
- Do we need media_array? If yes, why?

Do we need also this?
`elif prop == 'carousel_media':

    self.type = Media.TYPE_CAROUSEL
    self.carousel_media = []
    for carousel_array in arr["carousel_media"]:
        self.set_carousel_media(arr, carousel_array)`