### PR TITLE
get_media_likes_by_code returns an incorrect list of likes (always th…

### DIFF
--- a/igramscraper/instagram.py
+++ b/igramscraper/instagram.py
@@ -769,8 +769,6 @@ class Instagram:
                 index += remain
                 remain = 0
 
-            if (max_id != None):
-                max_id = ''
 
             variables = {
                 "shortcode": str(code),


### PR DESCRIPTION
…e first 50, repeated n times).

Caused by incorrect max_id setting in get_media_likes_by_code (redundant with the one that sets 'after' in the 'variables' dict)