### PR TITLE
fix incorrect paginate media request variables

### DIFF
--- a/igramscraper/instagram.py
+++ b/igramscraper/instagram.py
@@ -623,11 +623,11 @@ class Instagram:
             'hasNextPage': has_next_page,
         }
 
-        variables = json.dumps({
+        variables = {
             'id': str(account.identifier),
             'first': str(endpoints.request_media_count),
             'after': str(max_id)
-        }, separators=(',', ':'))
+        }
 
         time.sleep(self.sleep_between_requests)
         response = self.__req.get(


### PR DESCRIPTION
When I try to get the paginating media list by using method `get_paginate_medias`, I always met the 500 error, but when I try to use the method `get_medias`, it works.

So I printed the request URL try to find out what happened with the param, I got two different URLs:
1. `https://www.instagram.com/graphql/query/?query_hash=42323d64886122307be10013ad2dcc44&variables=%7b%22id%22%3a%2226492449224%22%2c%22first%22%3a%2220%22%2c%22after%22%3a%22%22%7d` from `get_medias`
2.  `https://www.instagram.com/graphql/query/?query_hash=42323d64886122307be10013ad2dcc44&variables=%22%7b%5c%22id%5c%22%3a%5c%2226492449224%5c%22%2c%5c%22first%5c%22%3a%5c%2230%5c%22%2c%5c%22after%5c%22%3a%5c%22%5c%22%7d%22` from `get_paginate_medias`

With the URL decode, I noticed that they have different parameters:
1. `query_hash=42323d64886122307be10013ad2dcc44&variables={"id":"26492449224","first":"20","after":""}` from `get_medias`
2. `query_hash=42323d64886122307be10013ad2dcc44&variables="{\"id\":\"26492449224\",\"first\":\"30\",\"after\":\"\"}"` from `get_paginate_medias`

Back to the codes, both `get_medias` and `get_paginate_medias` are using `get_account_medias_json_link` to generate URL for request, and `get_account_medias_json_link` will call `json.dumps`. But, here is the point, the method `get_paginate_medias` already processed the variables by using `json.dumps` before calling `get_account_medias_json_link`.

So, it looks like the `variables` in `get_paginate_medias` has been "dumped" twice, resulting in a 500 error.

I decided to remove the call to `json.dumps` in `get_paginate_medias`. I tested this fix, and it worked great.