### PR TITLE
added function to get number of comments

### DIFF
--- a/igramscraper/instagram.py
+++ b/igramscraper/instagram.py
@@ -1077,6 +1077,34 @@ class Instagram:
         data['comments'] = comments
         return data
 
+    def get_number_of_media_comments_by_id(self, media_id):
+        """
+        :param media_id: media id
+        :return: number of comments
+        """
+        code = Media.get_code_from_id(media_id)
+        variables = {
+            "shortcode": str(code),
+            "first": '0',
+            "after": ''
+            }
+        comments_url = endpoints.get_comments_before_comments_id_by_code(
+            variables)
+
+        time.sleep(self.sleep_between_requests)
+        response = self.__req.get(comments_url,
+                                  headers=self.generate_headers(
+                                      self.user_session,
+                                      self.__generate_gis_token(variables)))
+
+        if not response.status_code == Instagram.HTTP_OK:
+            raise InstagramException.default(response.text,
+                                             response.status_code)
+        jsonResponse = response.json()
+        number_of_comments = jsonResponse['data']['shortcode_media']['edge_media_to_parent_comment']['count']
+
+        return number_of_comments
+
     def get_account(self, username):
         """
         :param username: username


### PR DESCRIPTION
The function `get_media_comments_by_id` allows the user to get all the comments. However, often users are only interested in the number of comments and retrieving all of the comments is wasteful.
This PR adds a new function `get_number_of_media_comments_by_id` that simply returns this integer.