### PR TITLE
Remove slugify dependency.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,5 @@
 - test rate limits (highest priority)
 - add tests for like, unlike, comment, uncomment
 - improve documentation
-- removing slugify dependency (the less dependencies the better, only used on one spot instagram.py line 74)
 - simplify code while keeping functionality and readability
 - add private message functionality

--- a/igramscraper/instagram.py
+++ b/igramscraper/instagram.py
@@ -1,10 +1,10 @@
+import base64
 import time
 import requests
 import re
 import json
 import hashlib
 import os
-from slugify import slugify
 import random
 from .session_manager import CookieSessionManager
 from .exception.instagram_auth_exception import InstagramAuthException
@@ -52,7 +52,7 @@ class Instagram:
         """
         param string username
         param string password
-        param null sessionFolder
+        param null session_folder
 
         return Instagram
         """
@@ -63,15 +63,16 @@ class Instagram:
             session_folder = cwd + os.path.sep + 'sessions' + os.path.sep
 
         if isinstance(session_folder, str):
+            cookie_filename = str(username).strip().replace(' ', '_')
+            cookie_filename = re.sub(r'(?u)[^-\w.]', '', cookie_filename)
 
             Instagram.instance_cache = CookieSessionManager(
-                session_folder, slugify(username) + '.txt')
+                session_folder, cookie_filename + '.txt')
 
         else:
             Instagram.instance_cache = session_folder
 
         Instagram.instance_cache.empty_saved_cookies()
-
 
         self.session_username = username
         self.session_password = password

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests>=2.21.0
-python-slugify==3.0.2

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setuptools.setup(
     url='https://github.com/realsirjoe/instagram-scraper',
     install_requires=[
         'requests>=2.21.0',
-        'python-slugify==3.0.2'
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Copied function from django.utils.text.get_valid_filename. Seems like this would do the same thing as the slugify?
As per:
https://github.com/realsirjoe/instagram-scraper/blame/master/CONTRIBUTING.md#L6

I need this because I am trying to integrate into a project which already uses awesome-slugify and the 2 cannot coexist:
https://github.com/voronind/awesome-slugify/issues/37
